### PR TITLE
chore: downgrade minimum Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kunwardeep/paralleltest
 
-go 1.24
+go 1.23
 
 require golang.org/x/tools v0.31.0
 


### PR DESCRIPTION
The minimum Go version is a hard requirement for library consumers.

The Go version inside `toolchain` defines the Go version used to compile and doesn't affect lib consumers.

The minimum Go version can be either a "family name" (e.g. `1.23`) or a "release name" (e.g. `1.23.0`). It's important not to update the patch element to avoid forcing lib consumers to also update to this patched version.

The minimum Go version should only be used to define the minimum language version used to write.
